### PR TITLE
Fix Xsens Calibrator device

### DIFF
--- a/XSensMVN/src/XSensMVNCalibrator.cpp
+++ b/XSensMVN/src/XSensMVNCalibrator.cpp
@@ -169,7 +169,7 @@ namespace xsensmvn {
         }
 
         // Wait for the discard operation to be completed
-        while (!m_operationCompleted && !m_calibrationAborted) {
+        while (m_suitsConnector.isCalibrationPerformed(calibrationType) && !m_calibrationAborted) {
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
         }
         if (m_calibrationAborted) {
@@ -183,8 +183,9 @@ namespace xsensmvn {
         // Get the phases of the selected calibration type
         XsIntArray calibPhases = m_suitsConnector.calibrationPhaseList();
 
-        // Start the calibration data collection
+        // Start the calibration data collection (Wait three seconds to give the subject enough time to take position)
         xsInfo << "Starting " << calibrationType << " calibration" << std::endl;
+        std::this_thread::sleep_for(std::chrono::milliseconds(3000));
         m_suitsConnector.startCalibration();
 
         // Follow step-by-step the calibration phases of the selected type
@@ -270,14 +271,7 @@ namespace xsensmvn {
         }
         else {
             // Notify the user the calibration can be applied
-            xsInfo << "Ready to apply the obtained calibration. Stand still in starting position. "
-                      "Applying in: ";
-
-            // Wait three seconds to give the subject enough time to take position
-            for (int s = 5; s >= 0; --s) {
-                xsInfo << s << " s";
-                std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-            }
+            xsInfo << "Ready to apply the obtained calibration";
 
             // Apply the calibration to the MVN Engine and wait for a positive feedback
             m_suitsConnector.finalizeCalibration();


### PR DESCRIPTION
I found out what seems to be the problem with the `XsensMVNCalibrator` device when trying to discard the old calibration and recalibrate.

After discarding the old calibration there is a while loop waiting for discard operation to be completed (see https://github.com/robotology-playground/wearables/blob/feature/cleanup/XSensMVN/src/XSensMVNCalibrator.cpp#L171).
The termination of the waiting loop is determined by `m_operationCompleted` flag which is set to `true` by xsens callbacks [`onCalibrationAborted `](https://github.com/robotology-playground/wearables/blob/feature/cleanup/XSensMVN/src/XSensMVNCalibrator.cpp#L338), [`onCalibrationComplete `](https://github.com/robotology-playground/wearables/blob/feature/cleanup/XSensMVN/src/XSensMVNCalibrator.cpp#L341), and [`onCalibrationProcessed `](https://github.com/robotology-playground/wearables/blob/feature/cleanup/XSensMVN/src/XSensMVNCalibrator.cpp#L344). However it seems none of those callbacks is called after [`m_suitsConnector.clearCalibration()`](https://github.com/robotology-playground/wearables/blob/feature/cleanup/XSensMVN/src/XSensMVNCalibrator.cpp#L168) (or at least not in a reasonable time).

So, the `m_operationCompleted` flag is replaced by `m_suitsConnector.isCalibrationPerformed(calibrationType)` that checks whether the calibration is empty.

Moreover the 5-to-0 counter at 
https://github.com/robotology-playground/wearables/blob/master/XSensMVN/src/XSensMVNCalibrator.cpp#L273 seems to be completely unuseful since it is done once the calibration is already performed (the subject has to hold the position in the previous [while loop](https://github.com/robotology-playground/wearables/blob/master/XSensMVN/src/XSensMVNCalibrator.cpp#L196)) and nothing is going on at that point. I am then removing it
